### PR TITLE
Implemented clean for QuerySetRule

### DIFF
--- a/drip/models.py
+++ b/drip/models.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 from django.db import models
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 
 # just using this to parse, but totally insane package naming...
 # https://bitbucket.org/schinckel/django-timedelta-field/
@@ -88,6 +89,13 @@ class QuerySetRule(models.Model):
     field_value = models.CharField(max_length=255,
         help_text=('Can be anything from a number, to a string. Or, do ' +
                    '`now-7 days` or `now+3 days` for fancy timedelta.'))
+
+    def clean(self):
+        try:
+            self.apply(User.objects.all())
+        except Exception as e:
+            raise ValidationError(
+                '%s raised trying to apply rule: %s' % (type(e).__name__, e))
 
     def apply(self, qs, now=datetime.now):
         field_name = '__'.join([self.field_name, self.lookup_type])

--- a/drip/tests.py
+++ b/drip/tests.py
@@ -2,11 +2,32 @@ from datetime import datetime, timedelta
 
 from django.test import TestCase
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 
 from drip.models import Drip, SentDrip, QuerySetRule
 from drip.drips import DripBase
 from django.core.mail import EmailMultiAlternatives
 
+
+class RulesTestCase(TestCase):
+    def setUp(self):
+        self.drip = Drip.objects.create(
+            name='A Drip just for Rules',
+            subject_template='Hello',
+            body_html_template='KETTEHS ROCK!'
+        )
+
+    def test_valid_rule(self):
+        rule = QuerySetRule(drip=self.drip, field_name='date_joined', lookup_type='lte', field_value='now-60 days')
+        rule.clean()
+
+    def test_bad_field_name(self):
+        rule = QuerySetRule(drip=self.drip, field_name='date__joined', lookup_type='lte', field_value='now-60 days')
+        self.assertRaises(ValidationError, rule.clean)
+
+    def test_bad_field_value(self):
+        rule = QuerySetRule(drip=self.drip, field_name='date_joined', lookup_type='lte', field_value='now-2 months')
+        self.assertRaises(ValidationError, rule.clean)
 
 class DripsTestCase(TestCase):
     def setUp(self):


### PR DESCRIPTION
In clean, attempt to apply the rule and raise a validation error if apply
raises an exception. This prevents saving rules on drips in admin that
won't ever work.
