### PR TITLE
Feature request: timedeltas on dates (today-7 days, today+3 days)

### DIFF
--- a/drip/models.py
+++ b/drip/models.py
@@ -101,7 +101,7 @@ class QuerySetRule(models.Model):
     # would be nice if we could do a Count() object or something
     field_value = models.CharField(max_length=255,
         help_text=('Can be anything from a number, to a string. Or, do ' +
-                   '`now-7 days` or `now+3 days` for fancy timedelta.'))
+                   '`now-7 days` or `today+3 days` for fancy timedelta.'))
 
     def clean(self):
         try:
@@ -117,12 +117,16 @@ class QuerySetRule(models.Model):
         # set time deltas and dates
         if field_value.startswith('now-'):
             field_value = self.field_value.replace('now-', '')
-            delta = djangotimedelta.parse(field_value)
-            field_value = now() - delta
+            field_value = now() - djangotimedelta.parse(field_value)
         elif field_value.startswith('now+'):
             field_value = self.field_value.replace('now+', '')
-            delta = djangotimedelta.parse(field_value)
-            field_value = now() + delta
+            field_value = now() + djangotimedelta.parse(field_value)
+        elif field_value.startswith('today-'):
+            field_value = self.field_value.replace('today-', '')
+            field_value = now().date() - djangotimedelta.parse(field_value)
+        elif field_value.startswith('today+'):
+            field_value = self.field_value.replace('today+', '')
+            field_value = now().date() + djangotimedelta.parse(field_value)
 
         # set booleans
         if field_value == 'True':


### PR DESCRIPTION
As it stands, it's difficult to narrow down a drip to a specific day, for instance on the `date_joined` field. For example, If I want to send a message on a user's 6th day after joining I have to use two filters, `date_joined__gte, now-7` and `date_joined__lte, now-6`.

After this proposed patch, this can be accomplished with just one filter:
`date_joined__contains, today-6`
