### PR TITLE
Fixing deprecated module import

### DIFF
--- a/drip/admin.py
+++ b/drip/admin.py
@@ -75,7 +75,7 @@ class DripAdmin(admin.ModelAdmin):
             request, object_id, extra_context=self.build_extra_context(extra_context))
 
     def get_urls(self):
-        from django.conf.urls.defaults import patterns, url
+        from django.conf.urls import patterns, url
         urls = super(DripAdmin, self).get_urls()
         my_urls = patterns('',
             url(


### PR DESCRIPTION
django.conf.urls.defaults was deprecated in Django 1.5 and removed in Django 1.6
