### PR TITLE
Add support for Django 1.6

### DIFF
--- a/drip/admin.py
+++ b/drip/admin.py
@@ -75,7 +75,7 @@ class DripAdmin(admin.ModelAdmin):
             request, object_id, extra_context=self.build_extra_context(extra_context))
 
     def get_urls(self):
-        from django.conf.urls.defaults import patterns, url
+        from django.conf.urls import patterns, url
         urls = super(DripAdmin, self).get_urls()
         my_urls = patterns('',
             url(


### PR DESCRIPTION
Since `django.conf.urls.defaults` is removed in Django 1.6

ref: https://docs.djangoproject.com/en/1.4/topics/http/urls/#module-django.conf.urls
