### PR TITLE
Got tests passing in Django 1.4 - 1.7, python 2.7, 3.3, 3.4, and pypy; added classifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 build/
 docs/_build/
 *.egg-info/
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,30 @@
 language: python
+
 python:
-  - "2.6"
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "pypy"
+
 env:
-  - DJANGO_VERSION=1.3
-  - DJANGO_VERSION=1.4
+  - DJANGO_VERSION="1.4"
+  - DJANGO_VERSION="1.5"
+  - DJANGO_VERSION="1.6"
+  - DJANGO_VERSION="1.7"
+
 install:
-  - pip install -q Django==$DJANGO_VERSION --use-mirrors
-  - pip install -q -r requirements.txt --use-mirrors
+  - pip install "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99"
+  - pip install -r requirements.txt
+
 script: python manage.py test drip
+
+matrix:
+  exclude:
+    - python: "3.3"
+      env: DJANGO_VERSION="1.3"
+    - python: "3.4"
+      env: DJANGO_VERSION="1.3"
+    - python: "3.3"
+      env: DJANGO_VERSION="1.4"
+    - python: "3.4"
+      env: DJANGO_VERSION="1.4"

--- a/credits/models.py
+++ b/credits/models.py
@@ -6,11 +6,11 @@ class Profile(models.Model):
     """
     For testing, track the number of "credits".
     """
-    user = models.ForeignKey('auth.User')
+    user = models.OneToOneField('auth.User', related_name='profile')
     credits = models.PositiveIntegerField(default=0)
 
 
 def user_post_save(sender, instance, created, raw, **kwargs):
     if created:
-        profile = Profile.objects.create(user=instance)
+        Profile.objects.create(user=instance)
 models.signals.post_save.connect(user_post_save, sender=User)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ Django Drip is a simple app for creating drip campaigns for email using Django's
 
     # define the email template we want to send
     subject_template = 'Thanks {{ user.username }}!'
-    body_template = 'We appreciate you buying {{ user.get_profile.credits }} credits! Please buy more!'
+    body_template = 'We appreciate you buying {{ user.profile.credits }} credits! Please buy more!'
 
     # render and send the email
     for user in users:

--- a/drip/tests.py
+++ b/drip/tests.py
@@ -32,6 +32,7 @@ class RulesTestCase(TestCase):
 
 
 class DripsTestCase(TestCase):
+
     def setUp(self):
         """
         Creates 20 users, half of which buy 25 credits a day,
@@ -44,14 +45,13 @@ class DripsTestCase(TestCase):
             user = User.objects.create(username='%s_25_credits_a_day' % name, email='%s@test.com' % name)
             User.objects.filter(id=user.id).update(date_joined=start - timedelta(days=i))
 
-            profile = user.get_profile()
+            profile = user.profile
             profile.credits = i * 25
             profile.save()
 
         for i, name in enumerate(num_string):
             user = User.objects.create(username='%s_no_credits' % name, email='%s@test.com' % name)
             User.objects.filter(id=user.id).update(date_joined=start - timedelta(days=i))
-
 
     def test_users_exists(self):
         self.assertEqual(20, User.objects.all().count())
@@ -176,7 +176,7 @@ class DripsTestCase(TestCase):
 
         # vanilla (now-8, now-7), past (now-8-3, now-7-3), future (now-8+1, now-7+1)
         for count, shifted_drip in zip([0, 2, 2, 2, 2], drip.walk(into_past=3, into_future=2)):
-            self.assertEquals(count, shifted_drip.get_queryset().count())
+            self.assertEqual(count, shifted_drip.get_queryset().count())
 
         # no reason to change after a send...
         drip.send()
@@ -184,7 +184,7 @@ class DripsTestCase(TestCase):
 
         # vanilla (now-8, now-7), past (now-8-3, now-7-3), future (now-8+1, now-7+1)
         for count, shifted_drip in zip([0, 2, 2, 2, 2], drip.walk(into_past=3, into_future=2)):
-            self.assertEquals(count, shifted_drip.get_queryset().count())
+            self.assertEqual(count, shifted_drip.get_queryset().count())
 
     def test_custom_drip_with_count(self):
         model_drip = self.build_joined_date_drip()
@@ -199,7 +199,7 @@ class DripsTestCase(TestCase):
         self.assertEqual(1, drip.get_queryset().count()) # 1 person meet the criteria
 
         for count, shifted_drip in zip([0, 1, 1, 1, 1], drip.walk(into_past=3, into_future=2)):
-            self.assertEquals(count, shifted_drip.get_queryset().count())
+            self.assertEqual(count, shifted_drip.get_queryset().count())
 
     def test_custom_drip_static_datetime(self):
         model_drip = self.build_joined_date_drip()
@@ -212,7 +212,7 @@ class DripsTestCase(TestCase):
         drip = model_drip.drip
 
         for count, shifted_drip in zip([0, 2, 2, 0, 0], drip.walk(into_past=3, into_future=2)):
-            self.assertEquals(count, shifted_drip.get_queryset().count())
+            self.assertEqual(count, shifted_drip.get_queryset().count())
 
     def test_custom_drip_static_now_datetime(self):
         model_drip = Drip.objects.create(
@@ -230,7 +230,7 @@ class DripsTestCase(TestCase):
 
         # catches "today and yesterday" users
         for count, shifted_drip in zip([4, 4, 4, 4, 4], drip.walk(into_past=3, into_future=3)):
-            self.assertEquals(count, shifted_drip.get_queryset().count())
+            self.assertEqual(count, shifted_drip.get_queryset().count())
 
 
 # Used by CustomMessagesTest
@@ -268,16 +268,16 @@ class CustomMessagesTest(TestCase):
 
     def test_default_email(self):
         result = self.model_drip.drip.send()
-        self.assertEquals(1, result)
-        self.assertEquals(1, len(mail.outbox))
+        self.assertEqual(1, result)
+        self.assertEqual(1, len(mail.outbox))
         email = mail.outbox.pop()
         self.assertIsInstance(email, mail.EmailMultiAlternatives)
 
     def test_custom_added_not_used(self):
         settings.DRIP_MESSAGE_CLASSES = {'plain': 'drip.tests.PlainDripEmail'}
         result = self.model_drip.drip.send()
-        self.assertEquals(1, result)
-        self.assertEquals(1, len(mail.outbox))
+        self.assertEqual(1, result)
+        self.assertEqual(1, len(mail.outbox))
         email = mail.outbox.pop()
         # Since we did not specify custom class, default should be used.
         self.assertIsInstance(email, mail.EmailMultiAlternatives)
@@ -287,8 +287,8 @@ class CustomMessagesTest(TestCase):
         self.model_drip.message_class = 'plain'
         self.model_drip.save()
         result = self.model_drip.drip.send()
-        self.assertEquals(1, result)
-        self.assertEquals(1, len(mail.outbox))
+        self.assertEqual(1, result)
+        self.assertEqual(1, len(mail.outbox))
         email = mail.outbox.pop()
         # In this case we did specify the custom key, so message should be of custom type.
         self.assertIsInstance(email, mail.EmailMessage)
@@ -296,7 +296,7 @@ class CustomMessagesTest(TestCase):
     def test_override_default(self):
         settings.DRIP_MESSAGE_CLASSES = {'default': 'drip.tests.PlainDripEmail'}
         result = self.model_drip.drip.send()
-        self.assertEquals(1, result)
-        self.assertEquals(1, len(mail.outbox))
+        self.assertEqual(1, result)
+        self.assertEqual(1, len(mail.outbox))
         email = mail.outbox.pop()
         self.assertIsInstance(email, mail.EmailMessage)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # production
-Django>=1.3
-django-timedeltafield==0.6.7
+Django>=1.4
+django-timedeltafield==0.7.2
 
 # development
 Sphinx==1.1.3
-South==0.7.5
+South==1.0

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,9 @@ def get_package_data(package):
 if sys.argv[-1] == 'publish':
     os.system("python setup.py sdist upload")
     args = {'version': get_version(package)}
-    print "You probably want to also tag the version now:"
-    print "  git tag -a %(version)s -m 'version %(version)s'" % args
-    print "  git push --tags"
+    print("You probably want to also tag the version now:")
+    print("  git tag -a %(version)s -m 'version %(version)s'" % args)
+    print("  git push --tags")
     sys.exit()
 
 
@@ -69,5 +69,22 @@ setup(
     author_email=author_email,
     packages=get_packages(package),
     package_data=get_package_data(package),
-    install_requires=install_requires
+    install_requires=install_requires,
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: Web Environment',
+        'Framework :: Django',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
 )

--- a/testsettings.py
+++ b/testsettings.py
@@ -1,3 +1,4 @@
+SECRET_KEY = 'dripdripdripdripdripdripdrip'
 
 # MUST SPECIFY TO MAKE USE OF DJANGO DRIP
 DRIP_FROM_EMAIL = ''
@@ -19,5 +20,4 @@ INSTALLED_APPS = (
     'credits',
 )
 
-AUTH_PROFILE_MODULE = 'credits.Profile'
-
+MIDDLEWARE_CLASSES = ()


### PR DESCRIPTION
- Travis tests now run (and pass) for Django 1.4 - 1.7 (dropped 1.3 as it is no longer supported)
- Travis tests now run (and pass) using Python 2.7, 3.3, 3.4, and pypy (dropped 2.6)
- added PyPI classifiers for all tested versions of python
- changed the deprecated `User.get_profile()` pattern to a `OneToOneField` relation
- changed the deprecated `assertEquals` method to `assertEqual`
